### PR TITLE
Support format string message error raise 

### DIFF
--- a/peewee_validates.py
+++ b/peewee_validates.py
@@ -732,7 +732,7 @@ class Validator:
         self.initialize_fields()
 
     def add_error(self, name, error):
-        message = self._meta.messages.get('{}.{}'.format(name, error.key))
+        message = error.key if error.key else self._meta.messages.get("{}.{}".format(name, error.key))
         if not message:
             message = self._meta.messages.get(error.key)
         if not message:


### PR DESCRIPTION
In meta class we can provide only static messages as Custom Error Messages
but during the project there was requirements to provide dynamic message with computed string error message

